### PR TITLE
Add #include <cstdint>

### DIFF
--- a/lib/ReedSolomon.cpp
+++ b/lib/ReedSolomon.cpp
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <cstdio>
 #include <cstring>         // For memcpy
+#include <cstdint>
 
 extern "C" {
 #include "fec/fec.h"


### PR DESCRIPTION
Adding #include <cstdint> to prevent compilation error on Ubuntu 24.04.3LTS